### PR TITLE
Make `rvmn` exit with a meaningful exit status

### DIFF
--- a/bin/rmvn
+++ b/bin/rmvn
@@ -5,3 +5,5 @@ args = ARGV.dup
 ARGV.clear # clean up in case another script gets executed it gets clear ARGV
 
 RubyMaven.exec(*args)
+
+exit $?.exitstatus

--- a/spec/ruby_maven_spec.rb
+++ b/spec/ruby_maven_spec.rb
@@ -16,21 +16,21 @@ describe RubyMaven do
     end
   end
 
-  let :gem do
+  let :gem_name do
     v = Maven::Ruby::VERSION
     v += '-SNAPSHOT' if v =~ /[a-zA-Z]/
     "pkg/ruby-maven-#{v}.gem"
   end
 
   it 'pack the gem' do
-    FileUtils.rm_f gem
+    FileUtils.rm_f gem_name
     CatchStdout.exec do
       # need newer jruby version
       RubyMaven.exec( '-Dverbose', 'package', '-Djruby.version=1.7.24' )
     end
     #puts CatchStdout.result
     CatchStdout.result.must_match /mvn -Dverbose package/
-    File.exists?( gem ).must_equal true
+    File.exists?( gem_name ).must_equal true
     File.exists?( '.mvn/extensions.xml' ).must_equal true
     File.exists?( '.mvn/extensions.xml.orig' ).wont_equal true
   end


### PR DESCRIPTION
If the command it run under the hood failed, it should respect its status and fail too.

Helps with https://github.com/jruby/jruby-openssl/issues/199.

Also made an extra change so that the test suite at least starts.