### PR TITLE
No bundler warnings

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -8,6 +8,6 @@
   <extension>
     <groupId>io.takari.polyglot</groupId>
     <artifactId>polyglot-ruby</artifactId>
-    <version>0.4.4</version>
+    <version>0.4.8</version>
   </extension>
 </extensions>

--- a/lib/ruby_maven.rb
+++ b/lib/ruby_maven.rb
@@ -35,8 +35,14 @@ module RubyMaven
     elsif defined? Bundler
       # it can be switching from ruby to jruby with invoking maven
       # just keep it clean
-      Bundler.with_clean_env do
-        launch( *args )
+      if Bundler.respond_to?(:with_unbundled_env)
+        Bundler.with_unbundled_env do
+          launch( *args )
+        end
+      else
+        Bundler.with_clean_env do
+          launch( *args )
+        end
       end
     else
       launch( *args )

--- a/spec/maven_ruby_maven_spec.rb
+++ b/spec/maven_ruby_maven_spec.rb
@@ -8,18 +8,20 @@ describe Maven::Ruby::Maven do
   let(:pkg) { File.expand_path("../pkg", __dir__) }
 
   it 'shows mvn commandline with verbose flag' do
-    CatchStdout.exec do
+    out, _ = capture_subprocess_io do
       subject.exec( '-Dverbose', 'validate' )
     end
     subject.verbose = false
-    _(CatchStdout.result).must_match /mvn -Dverbose validate/
+    _(out).must_match /mvn -Dverbose validate/
   end
 
   it 'takes declared jruby version' do
     begin
       subject.inherit_jruby_version '9.0.4.0'
-      subject.exec( '-X', 'initialize', '-l', "#{pkg}/log1.txt" )
-      _(File.read("#{pkg}/log1.txt")).must_match /resolve jruby for version 9.0.4.0/
+      out, _ = capture_subprocess_io do
+        subject.exec( '-X', 'initialize')
+      end
+      _(out).must_match /resolve jruby for version 9.0.4.0/
     ensure
       subject['jruby.version'] = nil
     end
@@ -28,14 +30,18 @@ describe Maven::Ruby::Maven do
   if defined? JRUBY_VERSION
     it 'inherits jruby version' do
       subject.inherit_jruby_version
-      subject.exec( '-X', 'initialize', '-l', "#{pkg}/log2.txt" )
-      _(File.read("#{pkg}/log2.txt")).must_match /resolve jruby for version #{JRUBY_VERSION}/
+      out, _ = capture_subprocess_io do
+        subject.exec( '-X', 'initialize')
+      end
+      _(out).must_match /resolve jruby for version #{JRUBY_VERSION}/
     end
   else
     it 'takes default jruby version with inherit jruby version' do
       subject.inherit_jruby_version
-      subject.exec( '-X', 'initialize', '-l', "#{pkg}/log3.txt" )
-      _(File.read("#{pkg}/log3.txt")).must_match /resolve jruby for version 9.3.1.0/
+      out, _ = capture_subprocess_io do
+        subject.exec( '-X', 'initialize')
+      end
+      _(out).must_match /resolve jruby for version 9.3.1.0/
     end
   end
  end

--- a/spec/maven_ruby_maven_spec.rb
+++ b/spec/maven_ruby_maven_spec.rb
@@ -5,6 +5,8 @@ describe Maven::Ruby::Maven do
 
   subject { Maven::Ruby::Maven.new }
 
+  let(:pkg) { File.expand_path("../pkg", __dir__) }
+
   it 'shows mvn commandline with verbose flag' do
     CatchStdout.exec do
       subject.exec( '-Dverbose', 'validate' )
@@ -16,8 +18,8 @@ describe Maven::Ruby::Maven do
   it 'takes declared jruby version' do
     begin
       subject.inherit_jruby_version '9.0.4.0'
-      subject.exec( '-X', 'initialize', '-l', 'pkg/log1.txt' )
-      _(File.read('pkg/log1.txt')).must_match /resolve jruby for version 9.0.4.0/
+      subject.exec( '-X', 'initialize', '-l', "#{pkg}/log1.txt" )
+      _(File.read("#{pkg}/log1.txt")).must_match /resolve jruby for version 9.0.4.0/
     ensure
       subject['jruby.version'] = nil
     end
@@ -26,14 +28,14 @@ describe Maven::Ruby::Maven do
   if defined? JRUBY_VERSION
     it 'inherits jruby version' do
       subject.inherit_jruby_version
-      subject.exec( '-X', 'initialize', '-l', 'pkg/log2.txt' )
-      _(File.read('pkg/log2.txt')).must_match /resolve jruby for version #{JRUBY_VERSION}/
+      subject.exec( '-X', 'initialize', '-l', "#{pkg}/log2.txt" )
+      _(File.read("#{pkg}/log2.txt")).must_match /resolve jruby for version #{JRUBY_VERSION}/
     end
   else
     it 'takes default jruby version with inherit jruby version' do
       subject.inherit_jruby_version
-      subject.exec( '-X', 'initialize', '-l', 'pkg/log3.txt' )
-      _(File.read('pkg/log3.txt')).must_match /resolve jruby for version 9.3.1.0/
+      subject.exec( '-X', 'initialize', '-l', "#{pkg}/log3.txt" )
+      _(File.read("#{pkg}/log3.txt")).must_match /resolve jruby for version 9.3.1.0/
     end
   end
  end

--- a/spec/ruby_maven_spec.rb
+++ b/spec/ruby_maven_spec.rb
@@ -7,10 +7,10 @@ describe RubyMaven do
 
   it 'displays the version info' do
     Dir.chdir 'spec' do
-      CatchStdout.exec do
+      _, err = capture_io do
         RubyMaven.exec( '--version' )
       end
-      _(CatchStdout.result).must_match /Polyglot Maven Extension 0.4.8/
+      _(err).must_match /Polyglot Maven Extension 0.4.8/
       xml = File.read('.mvn/extensions.xml')
       _(xml).must_equal "dummy\n"
     end
@@ -24,12 +24,11 @@ describe RubyMaven do
 
   it 'pack the gem' do
     FileUtils.rm_f gem_name
-    CatchStdout.exec do
+      out, _ = capture_subprocess_io do
       # need newer jruby version
       RubyMaven.exec( '-Dverbose', 'package', '-Djruby.version=9.3.0.0' )
     end
-    #puts CatchStdout.result
-    _(CatchStdout.result).must_match /mvn -Dverbose package/
+    _(out).must_match /mvn -Dverbose package/
     _(File.exists?( gem_name )).must_equal true
     _(File.exists?( '.mvn/extensions.xml' )).must_equal true
     _(File.exists?( '.mvn/extensions.xml.orig' )).wont_equal true

--- a/spec/ruby_maven_spec.rb
+++ b/spec/ruby_maven_spec.rb
@@ -10,7 +10,7 @@ describe RubyMaven do
       CatchStdout.exec do
         RubyMaven.exec( '--version' )
       end
-      _(CatchStdout.result).must_match /Polyglot Maven Extension 0.4.4/
+      _(CatchStdout.result).must_match /Polyglot Maven Extension 0.4.8/
       xml = File.read('.mvn/extensions.xml')
       _(xml).must_equal "dummy\n"
     end

--- a/spec/setup.rb
+++ b/spec/setup.rb
@@ -1,8 +1,4 @@
 $LOAD_PATH.unshift File.expand_path( '../../lib', __FILE__ )
-begin
-  require 'minitest'
-rescue LoadError
-end
 require 'minitest/autorun'
 
 

--- a/spec/setup.rb
+++ b/spec/setup.rb
@@ -3,23 +3,3 @@ $LOAD_PATH.unshift File.expand_path( '../../lib', __FILE__ )
 ENV["MT_NO_PLUGINS"] = "true"
 
 require 'minitest/autorun'
-
-
-module CatchStdout
-
-  def self.exec
-    out = $stdout
-    err = $stderr
-    @result = StringIO.new
-    $stdout = @result
-    $stderr = @result
-    yield
-  ensure
-    $stdout = out
-    $stderr = err
-  end
-
-  def self.result
-    @result.string
-  end
-end

--- a/spec/setup.rb
+++ b/spec/setup.rb
@@ -1,4 +1,7 @@
 $LOAD_PATH.unshift File.expand_path( '../../lib', __FILE__ )
+
+ENV["MT_NO_PLUGINS"] = "true"
+
 require 'minitest/autorun'
 
 


### PR DESCRIPTION
Avoid using method deprecated in recent bundler versions.

I also added MacOS to the CI because I can't reproduce the CI issues locally and I'm using MacOS, so I want to double check whether it could be related to the OS somehow.